### PR TITLE
Fix color picker default and logo URL validation

### DIFF
--- a/src/components/common/ColorPicker.jsx
+++ b/src/components/common/ColorPicker.jsx
@@ -1,7 +1,9 @@
 import React from "react"
 
+const DEFAULT_COLOR = "#000000"
+
 export default function ColorPicker({ label, value, onChange }) {
-  const display = value ?? defaultValue
+  const display = value ?? DEFAULT_COLOR
 
   return (
     <label className="block">

--- a/src/components/features/UploadLogo/components/LogoUrlInput.jsx
+++ b/src/components/features/UploadLogo/components/LogoUrlInput.jsx
@@ -17,8 +17,8 @@ export default function LogoUrlInput() {
       const img = new Image();
       img.onload = () => setError("");
       img.onerror = () => setError("URL non valide");
-      
-      img.src = value;
+
+      img.src = logoSrc;
     } catch (e) {
       setError("URL non valide");
       
@@ -35,7 +35,6 @@ export default function LogoUrlInput() {
       setLogoName("")
       setLogoSrc(e.target.value)
     }}
-    onBlur={() => validateAndSave(inputValue)}
     onPaste={e => {
       e.preventDefault()
       const url = e.clipboardData.getData("text/plain").trim()


### PR DESCRIPTION
## Summary
- prevent undefined default value in `ColorPicker`
- validate logo URL correctly and remove unused handler

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6878f3b4a8c08329b55f850257ddce18